### PR TITLE
Implement fuel price discount

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -92,11 +92,13 @@ async function scrapeFuelPrices() {
             // Generate prices for different stations with slight variations
             Object.entries(cityCoordinates).forEach(([city, coords]) => {
               const variation = (Math.random() - 0.5) * 0.1; // ±0.05€ variation
+              const basePrice = price + variation;
+              const discountedPrice = +(basePrice * 0.92).toFixed(3); // 8% discount
               prices.push({
                 id: `${city}-${standardizedFuelType}`.toLowerCase(),
                 stationName: `${city} Station`,
                 fuelType: standardizedFuelType,
-                price: +(price + variation).toFixed(3),
+                price: discountedPrice,
                 lat: coords.lat,
                 lng: coords.lng,
                 updatedAt: new Date().toISOString()


### PR DESCRIPTION
## Summary
- scrape fuel prices and apply an 8% discount before returning them via the API

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6846cedf057c832eb09c64da0e6187c9